### PR TITLE
Rename project from fluent-test to rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.0 (2025-04-27)
+
+### Changed
+
+- Renamed project from "fluent-test" to "rest"
+  - Updated package name to "rest" on crates.io
+  - Changed macro crate name to "rest-macros"
+  - Renamed API import paths from `fluent_test::*` to `rest::*`
+  - Updated environment variable from `FLUENT_TEST_ENHANCED_OUTPUT` to `REST_ENHANCED_OUTPUT`
+  - Renamed `fluent_test` macro to `rest_test`
+  - Updated all documentation and examples to use new name
+  - Renamed GitHub repository URLs
+
 ## 0.4.3 (Unreleased)
 
 ### Added
@@ -94,7 +107,7 @@
 
 - Added enhanced configuration system:
   - Simplified API with `config().enhanced_output(true).apply()`
-  - Support for environment variable `FLUENT_TEST_ENHANCED_OUTPUT`
+  - Support for environment variable `REST_ENHANCED_OUTPUT`
   - New example files demonstrating configuration options
 - Added new example files:
   - `config_example.rs` - Shows configuration options
@@ -186,7 +199,7 @@
 
 ### Added
 
-- Initial implementation of FluentTest, a Jest-like testing library for Rust
+- Initial implementation of Rest, a Jest-like testing library for Rust
 - Core expectation and matcher system
 - Fluent assertion API with `expect!` macro
 - Negation support with `.not()` method and `expect_not!` macro

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# FluentTest Development Guide
+# Rest Development Guide
 
 ## Build Commands
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,28 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fluent-test"
-version = "0.4.3"
-dependencies = [
- "colored",
- "ctor",
- "fluent-test-macros",
- "lazy_static",
- "once_cell",
- "regex",
- "thread_local",
-]
-
-[[package]]
-name = "fluent-test-macros"
-version = "0.4.3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +101,28 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rest"
+version = "0.5.0"
+dependencies = [
+ "colored",
+ "ctor",
+ "lazy_static",
+ "once_cell",
+ "regex",
+ "rest-macros",
+ "thread_local",
+]
+
+[[package]]
+name = "rest-macros"
+version = "0.5.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "fluent-test"
-version = "0.4.3"
+name = "rest"
+version = "0.5.0"
 edition = "2024"
 authors = ["Romain Laneuville<romain.laneuville@hotmail.fr>"]
 description = "A fluent, Jest-like testing library for Rust"
-repository = "https://github.com/mister-good-deal/fluent-test"
+repository = "https://github.com/mister-good-deal/rest"
 license = "MIT"
 keywords = ["testing", "test", "jest", "fluent", "assertions"]
 categories = ["development-tools", "development-tools::testing"]
@@ -16,11 +16,11 @@ lazy_static = "1.4.0"
 thread_local = "1.1.8"
 once_cell = "1.18.0"
 ctor = "0.2.7"
-fluent-test-macros = { path = "./fluent-test-macros", version = "0.4.3" }
+rest-macros = { path = "./rest-macros", version = "0.5.0" }
 
 [dev-dependencies]
 
 [workspace]
 members = [
-    "fluent-test-macros"
+    "rest-macros"
 ]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# FluentTest
+# Rest
 
-[![Crates.io](https://img.shields.io/crates/v/fluent-test.svg)](https://crates.io/crates/fluent-test)
-[![Build Status](https://github.com/mister-good-deal/fluent-test/workflows/CI/badge.svg)](https://github.com/mister-good-deal/fluent-test/actions)
-[![codecov](https://codecov.io/gh/mister-good-deal/fluent-test/graph/badge.svg?token=W5L8E2CQ9M)](https://codecov.io/gh/mister-good-deal/fluent-test)
-[![License](https://img.shields.io/crates/l/fluent-test.svg)](https://github.com/mister-good-deal/fluent-test/blob/master/LICENSE)
-[![Downloads](https://img.shields.io/crates/d/fluent-test.svg)](https://crates.io/crates/fluent-test)
+[![Crates.io](https://img.shields.io/crates/v/rest.svg)](https://crates.io/crates/rest)
+[![Build Status](https://github.com/mister-good-deal/rest/workflows/CI/badge.svg)](https://github.com/mister-good-deal/rest/actions)
+[![codecov](https://codecov.io/gh/mister-good-deal/rest/graph/badge.svg?token=W5L8E2CQ9M)](https://codecov.io/gh/mister-good-deal/rest)
+[![License](https://img.shields.io/crates/l/rest.svg)](https://github.com/mister-good-deal/rest/blob/master/LICENSE)
+[![Downloads](https://img.shields.io/crates/d/rest.svg)](https://crates.io/crates/rest)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10418/badge)](https://www.bestpractices.dev/projects/10418)
 
-A fluent, Jest-like testing library for Rust that builds upon the standard testing infrastructure. FluentTest provides
+A fluent, Jest-like testing library for Rust that builds upon the standard testing infrastructure. Rest provides
 expressive assertions with readable error messages while maintaining compatibility with Rust's built-in testing functionality.
 
 ## Features
@@ -45,20 +45,20 @@ expressive assertions with readable error messages while maintaining compatibili
 
 ## Quick Start
 
-Add FluentTest to your project:
+Add Rest to your project:
 
 ```bash
-cargo add fluent-test --dev
+cargo add rest --dev
 ```
 
 Write your first test:
 
 ```rust
-use fluent_test::prelude::*;
+use rest::prelude::*;
 
 #[test]
 fn should_check_values() {
-    // By default, FluentTest behaves like standard Rust assertions
+    // By default, Rest behaves like standard Rust assertions
     // To enable enhanced output, configure it:
     config().enhanced_output(true).apply();
     
@@ -75,28 +75,28 @@ fn should_check_values() {
 You can also enable enhanced output globally by setting the environment variable:
 
 ```bash
-FLUENT_TEST_ENHANCED_OUTPUT=true cargo test
+REST_ENHANCED_OUTPUT=true cargo test
 ```
 
 ## Available Matchers
 
-FluentTest provides a comprehensive set of matchers for various types. All matchers support negation through either the
+Rest provides a comprehensive set of matchers for various types. All matchers support negation through either the
 `not()` method or the `expect_not!` macro.
 
-For complete documentation of all matchers, please see the [Wiki documentation](https://github.com/mister-good-deal/fluent-test/wiki).
+For complete documentation of all matchers, please see the [Wiki documentation](https://github.com/mister-good-deal/rest/wiki).
 
 ### Boolean Matchers
 
 - **to_be_true** - Checks if a boolean is true
 - **to_be_false** - Checks if a boolean is false
 
-[View Boolean Matchers documentation](https://github.com/mister-good-deal/fluent-test/wiki/Boolean-Matchers)
+[View Boolean Matchers documentation](https://github.com/mister-good-deal/rest/wiki/Boolean-Matchers)
 
 ### Equality Matchers
 
 - **to_equal** - Checks if a value equals another value
 
-[View Equality Matchers documentation](https://github.com/mister-good-deal/fluent-test/wiki/Equality-Matchers)
+[View Equality Matchers documentation](https://github.com/mister-good-deal/rest/wiki/Equality-Matchers)
 
 ### Numeric Matchers
 
@@ -111,7 +111,7 @@ For complete documentation of all matchers, please see the [Wiki documentation](
 - **to_be_negative** - Checks if a number is negative
 - **to_be_in_range** - Checks if a number is within a specified range
 
-[View Numeric Matchers documentation](https://github.com/mister-good-deal/fluent-test/wiki/Numeric-Matchers)
+[View Numeric Matchers documentation](https://github.com/mister-good-deal/rest/wiki/Numeric-Matchers)
 
 ### String Matchers
 
@@ -122,7 +122,7 @@ For complete documentation of all matchers, please see the [Wiki documentation](
 - **to_match** - Checks if a string matches a pattern
 - **to_have_length** - Checks if a string has a specific length
 
-[View String Matchers documentation](https://github.com/mister-good-deal/fluent-test/wiki/String-Matchers)
+[View String Matchers documentation](https://github.com/mister-good-deal/rest/wiki/String-Matchers)
 
 ### Collection Matchers
 
@@ -132,7 +132,7 @@ For complete documentation of all matchers, please see the [Wiki documentation](
 - **to_contain_all_of** - Checks if a collection contains all specified elements
 - **to_equal_collection** - Compares two collections for element-wise equality
 
-[View Collection Matchers documentation](https://github.com/mister-good-deal/fluent-test/wiki/Collection-Matchers)
+[View Collection Matchers documentation](https://github.com/mister-good-deal/rest/wiki/Collection-Matchers)
 
 ### HashMap Matchers
 
@@ -141,7 +141,7 @@ For complete documentation of all matchers, please see the [Wiki documentation](
 - **to_contain_key** - Checks if a HashMap contains a specific key
 - **to_contain_entry** - Checks if a HashMap contains a specific key-value pair
 
-[View HashMap Matchers documentation](https://github.com/mister-good-deal/fluent-test/wiki/HashMap-Matchers)
+[View HashMap Matchers documentation](https://github.com/mister-good-deal/rest/wiki/HashMap-Matchers)
 
 ### Option Matchers
 
@@ -149,7 +149,7 @@ For complete documentation of all matchers, please see the [Wiki documentation](
 - **to_be_none** - Checks if an Option is None
 - **to_contain_value** - Checks if an Option contains a specific value
 
-[View Option Matchers documentation](https://github.com/mister-good-deal/fluent-test/wiki/Option-Matchers)
+[View Option Matchers documentation](https://github.com/mister-good-deal/rest/wiki/Option-Matchers)
 
 ### Result Matchers
 
@@ -158,11 +158,11 @@ For complete documentation of all matchers, please see the [Wiki documentation](
 - **to_contain_ok** - Checks if a Result contains a specific Ok value
 - **to_contain_err** - Checks if a Result contains a specific Err value
 
-[View Result Matchers documentation](https://github.com/mister-good-deal/fluent-test/wiki/Result-Matchers)
+[View Result Matchers documentation](https://github.com/mister-good-deal/rest/wiki/Result-Matchers)
 
 ## Using Modifiers
 
-FluentTest provides powerful modifiers to create complex assertions, including:
+Rest provides powerful modifiers to create complex assertions, including:
 
 - Negation with the `.not()` method or `expect_not!` macro
 - Logical chaining with `.and()` and `.or()` operators
@@ -178,14 +178,14 @@ expect!(number).to_be_greater_than(30)
 expect!(value).not().to_equal(100);
 ```
 
-[View Using Modifiers documentation](https://github.com/mister-good-deal/fluent-test/wiki/Using-Modifiers)
+[View Using Modifiers documentation](https://github.com/mister-good-deal/rest/wiki/Using-Modifiers)
 
 ## Test Fixtures
 
-FluentTest provides a powerful fixture system for setting up and tearing down test environments:
+Rest provides a powerful fixture system for setting up and tearing down test environments:
 
 ```rust
-use fluent_test::prelude::*;
+use rest::prelude::*;
 
 // Define setup function
 #[setup]
@@ -218,39 +218,39 @@ Key features:
 - Automatic cleanup on test failures
 - Multiple setup/teardown functions per module
 
-[View Test Fixtures documentation](https://github.com/mister-good-deal/fluent-test/wiki/Fixtures)
+[View Test Fixtures documentation](https://github.com/mister-good-deal/rest/wiki/Fixtures)
 
 ## Custom Matchers
 
-FluentTest is designed to be easily extensible. You can create your own custom matchers to make your tests more expressive and domain-specific.
+Rest is designed to be easily extensible. You can create your own custom matchers to make your tests more expressive and domain-specific.
 
-[View Custom Matchers documentation](https://github.com/mister-good-deal/fluent-test/wiki/Custom-Matchers)
+[View Custom Matchers documentation](https://github.com/mister-good-deal/rest/wiki/Custom-Matchers)
 
 ## Output Formatting
 
-FluentTest enhances the standard test output with colors, symbols, and improved formatting:
+Rest enhances the standard test output with colors, symbols, and improved formatting:
 
 - **Color Coding**: Green for passing tests, red for failing tests
 - **Unicode Symbols**: Check (✓) marks for passing conditions, cross (✗) for failing ones
 - **Clean Variable Names**: Reference symbols (`&`) are automatically removed from output
 - **Consistent Indentation**: Multi-line output is properly indented for readability
 
-[View Output Formatting documentation](https://github.com/mister-good-deal/fluent-test/wiki/Output-Formatting)
+[View Output Formatting documentation](https://github.com/mister-good-deal/rest/wiki/Output-Formatting)
 
 ## Architecture
 
-FluentTest uses a modular, event-driven architecture:
+Rest uses a modular, event-driven architecture:
 
 - **Backend Layer** - Core assertion evaluation logic
 - **Config System** - Controls the library's behavior
 - **Event System** - Decouples assertion execution from reporting
 - **Frontend Layer** - Reporting and user interface
 
-[View Architecture documentation](https://github.com/mister-good-deal/fluent-test/wiki/Architecture)
+[View Architecture documentation](https://github.com/mister-good-deal/rest/wiki/Architecture)
 
 ## Releases
 
-This project is automatically published to [crates.io](https://crates.io/crates/fluent-test) when:
+This project is automatically published to [crates.io](https://crates.io/crates/rest) when:
 
 1. The version in Cargo.toml is increased beyond the latest git tag
 2. The code is merged to the master branch
@@ -277,7 +277,7 @@ Coverage reports are automatically generated on each push to the master branch a
 
 ### Viewing Coverage Reports
 
-- The latest coverage report is always available on [Codecov.io](https://codecov.io/gh/mister-good-deal/fluent-test)
+- The latest coverage report is always available on [Codecov.io](https://codecov.io/gh/mister-good-deal/rest)
 - Each CI run also produces an HTML coverage report available as a downloadable artifact
 
 ### Running Code Coverage Locally

--- a/examples/attribute_fixtures.rs
+++ b/examples/attribute_fixtures.rs
@@ -1,4 +1,4 @@
-use fluent_test::prelude::*;
+use rest::prelude::*;
 use std::cell::RefCell;
 
 // A shared counter for demonstration

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,4 @@
-use fluent_test::prelude::*;
+use rest::prelude::*;
 
 fn main() {
     // Enable enhanced output for this example
@@ -27,5 +27,5 @@ fn main() {
     expect!(name_ref).to_equal(&arthur);
 
     // Report test results
-    fluent_test::Reporter::summarize();
+    rest::Reporter::summarize();
 }

--- a/examples/combined_matchers.rs
+++ b/examples/combined_matchers.rs
@@ -1,6 +1,6 @@
 mod common;
 use common::guard_test;
-use fluent_test::prelude::*;
+use rest::prelude::*;
 use std::collections::HashMap;
 
 fn main() {

--- a/examples/config_example.rs
+++ b/examples/config_example.rs
@@ -1,4 +1,4 @@
-use fluent_test::prelude::*;
+use rest::prelude::*;
 
 // This binary shows different configuration options for FluentTest
 fn main() {

--- a/examples/conjugation.rs
+++ b/examples/conjugation.rs
@@ -1,4 +1,4 @@
-use fluent_test::prelude::*;
+use rest::prelude::*;
 
 fn main() {
     // Enable enhanced output for this example
@@ -45,5 +45,5 @@ fn main() {
     expect!(user).to_equal("John"); // Should be "user is equal to 'John'"
     expect!(&users).to_contain("Alice"); // Should be "users contain 'Alice'"
 
-    fluent_test::Reporter::summarize();
+    rest::Reporter::summarize();
 }

--- a/examples/enhanced_output.rs
+++ b/examples/enhanced_output.rs
@@ -1,4 +1,4 @@
-use fluent_test::prelude::*;
+use rest::prelude::*;
 
 fn main() {
     println!("FluentTest Enhanced Output Example\n");

--- a/examples/fixtures_example.rs
+++ b/examples/fixtures_example.rs
@@ -1,4 +1,4 @@
-use fluent_test::prelude::*;
+use rest::prelude::*;
 use std::cell::RefCell;
 
 // A shared counter for demonstration

--- a/examples/logical_chain.rs
+++ b/examples/logical_chain.rs
@@ -1,6 +1,6 @@
 mod common;
 use common::guard_test;
-use fluent_test::prelude::*;
+use rest::prelude::*;
 
 fn main() {
     // Enable enhanced output for this example

--- a/examples/modifiers.rs
+++ b/examples/modifiers.rs
@@ -1,6 +1,6 @@
 mod common;
 use common::guard_test;
-use fluent_test::prelude::*;
+use rest::prelude::*;
 
 fn main() {
     // Enable enhanced output for this example
@@ -40,5 +40,5 @@ fn main() {
 
     // Report test results
     println!("\n=== Test Summary ===");
-    fluent_test::Reporter::summarize();
+    rest::Reporter::summarize();
 }

--- a/examples/module_fixtures.rs
+++ b/examples/module_fixtures.rs
@@ -1,4 +1,4 @@
-use fluent_test::prelude::*;
+use rest::prelude::*;
 use std::cell::RefCell;
 
 // A shared counter for demonstration

--- a/examples/module_lifecycle.rs
+++ b/examples/module_lifecycle.rs
@@ -1,4 +1,4 @@
-use fluent_test::prelude::*;
+use rest::prelude::*;
 use std::cell::RefCell;
 use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/examples/new_matchers.rs
+++ b/examples/new_matchers.rs
@@ -1,4 +1,4 @@
-use fluent_test::prelude::*;
+use rest::prelude::*;
 use std::collections::HashMap;
 
 fn main() {
@@ -51,5 +51,5 @@ fn main() {
     expect!(&user_scores).not().to_contain_key("Charlie");
 
     // Report test results
-    fluent_test::Reporter::summarize();
+    rest::Reporter::summarize();
 }

--- a/examples/not_modifier.rs
+++ b/examples/not_modifier.rs
@@ -1,4 +1,4 @@
-use fluent_test::prelude::*;
+use rest::prelude::*;
 
 fn main() {
     // Enable enhanced output for this example

--- a/rest-macros/Cargo.toml
+++ b/rest-macros/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "fluent-test-macros"
-version = "0.4.3"
+name = "rest-macros"
+version = "0.5.0"
 edition = "2024"
 authors = ["Romain Laneuville<romain.laneuville@hotmail.fr>"]
-description = "Procedural macros for fluent-test"
-repository = "https://github.com/mister-good-deal/fluent-test"
+description = "Procedural macros for rest"
+repository = "https://github.com/mister-good-deal/rest"
 license = "MIT"
 keywords = ["testing", "test", "jest", "fluent", "assertions"]
 categories = ["development-tools", "development-tools::testing"]

--- a/rest-macros/src/lib.rs
+++ b/rest-macros/src/lib.rs
@@ -9,7 +9,7 @@ use syn::{
 ///
 /// Example:
 /// ```
-/// use fluent_test::prelude::*;
+/// use rest::prelude::*;
 ///
 /// #[before_all]
 /// fn setup_once() {
@@ -30,7 +30,7 @@ pub fn before_all(_attr: TokenStream, item: TokenStream) -> TokenStream {
         // We use ctor to register the function at runtime
         #[ctor::ctor]
         fn #register_fn_name() {
-            fluent_test::backend::fixtures::register_before_all(
+            rest::backend::fixtures::register_before_all(
                 module_path!(),
                 Box::new(|| #fn_name())
             );
@@ -44,7 +44,7 @@ pub fn before_all(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// Example:
 /// ```
-/// use fluent_test::prelude::*;
+/// use rest::prelude::*;
 ///
 /// #[after_all]
 /// fn teardown_once() {
@@ -65,7 +65,7 @@ pub fn after_all(_attr: TokenStream, item: TokenStream) -> TokenStream {
         // We use ctor to register the function at runtime
         #[ctor::ctor]
         fn #register_fn_name() {
-            fluent_test::backend::fixtures::register_after_all(
+            rest::backend::fixtures::register_after_all(
                 module_path!(),
                 Box::new(|| #fn_name())
             );
@@ -79,7 +79,7 @@ pub fn after_all(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// Example:
 /// ```
-/// use fluent_test::prelude::*;
+/// use rest::prelude::*;
 ///
 /// #[setup]
 /// fn setup() {
@@ -100,7 +100,7 @@ pub fn setup(_attr: TokenStream, item: TokenStream) -> TokenStream {
         // We use ctor to register the function at runtime
         #[ctor::ctor]
         fn #register_fn_name() {
-            fluent_test::backend::fixtures::register_setup(
+            rest::backend::fixtures::register_setup(
                 module_path!(),
                 Box::new(|| #fn_name())
             );
@@ -114,7 +114,7 @@ pub fn setup(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// Example:
 /// ```
-/// use fluent_test::prelude::*;
+/// use rest::prelude::*;
 ///
 /// #[tear_down]
 /// fn tear_down() {
@@ -135,7 +135,7 @@ pub fn tear_down(_attr: TokenStream, item: TokenStream) -> TokenStream {
         // We use ctor to register the function at runtime
         #[ctor::ctor]
         fn #register_fn_name() {
-            fluent_test::backend::fixtures::register_teardown(
+            rest::backend::fixtures::register_teardown(
                 module_path!(),
                 Box::new(|| #fn_name())
             );
@@ -149,7 +149,7 @@ pub fn tear_down(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// Example:
 /// ```
-/// use fluent_test::prelude::*;
+/// use rest::prelude::*;
 ///
 /// #[with_fixtures]
 /// fn test_something() {
@@ -179,7 +179,7 @@ pub fn with_fixtures(_attr: TokenStream, item: TokenStream) -> TokenStream {
             // Get the current module path - critical for finding the right fixtures
             let module_path = module_path!();
 
-            fluent_test::backend::fixtures::run_test_with_fixtures(
+            rest::backend::fixtures::run_test_with_fixtures(
                 module_path,
                 std::panic::AssertUnwindSafe(|| #impl_name())
             );
@@ -218,7 +218,7 @@ impl VisitMut for TestFunctionVisitor {
 ///
 /// Example:
 /// ```
-/// use fluent_test::prelude::*;
+/// use rest::prelude::*;
 ///
 /// #[with_fixtures_module]
 /// mod test_module {

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,9 +5,9 @@ use std::sync::Once;
 static INIT: Once = Once::new();
 
 // Environment variable to control enhanced output
-const ENV_ENHANCED_OUTPUT: &str = "FLUENT_TEST_ENHANCED_OUTPUT";
+const ENV_ENHANCED_OUTPUT: &str = "REST_ENHANCED_OUTPUT";
 
-/// Configuration for FluentTest's output and behavior
+/// Configuration for Rest's output and behavior
 pub struct Config {
     pub(crate) use_colors: bool,
     pub(crate) use_unicode_symbols: bool,
@@ -88,7 +88,7 @@ impl Config {
     }
 }
 
-/// Initialize the FluentTest system
+/// Initialize the Rest system
 /// This is called automatically when needed but can also be called explicitly
 pub fn initialize() {
     INIT.call_once(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! FluentTest: A fluent, Jest-like testing library for Rust
+//! Rest: A fluent, Jest-like testing library for Rust
 //!
 //! This crate provides a more expressive way to write tests in Rust,
 //! inspired by JavaScript testing frameworks like Jest.
@@ -8,17 +8,17 @@
 //!
 //! ```
 //! // In your test code:
-//! use fluent_test::prelude::*;
+//! use rest::prelude::*;
 //!
 //! fn my_test() {
 //!     // Enable enhanced output for this test
-//!     fluent_test::config().enhanced_output(true).apply();
+//!     rest::config().enhanced_output(true).apply();
 //!     
 //!     expect!(2 + 2).to_equal(4);
 //! }
 //! ```
 //!
-//! Or set the FLUENT_TEST_ENHANCED_OUTPUT=true environment variable.
+//! Or set the REST_ENHANCED_OUTPUT=true environment variable.
 
 // Allow explicit return statements as part of the coding style
 #![allow(clippy::needless_return)]
@@ -53,7 +53,7 @@ pub fn auto_initialize_for_tests() {
 pub use config::initialize;
 
 // Export attribute macros for fixtures
-pub use fluent_test_macros::{after_all, before_all, setup, tear_down, with_fixtures, with_fixtures_module};
+pub use rest_macros::{after_all, before_all, setup, tear_down, with_fixtures, with_fixtures_module};
 
 // Global exit handler for after_all fixtures
 #[ctor::dtor]
@@ -129,15 +129,15 @@ macro_rules! expect_not {
     }};
 }
 
-/// Run all FluentTest tests in a module
+/// Run all Rest tests in a module
 ///
 /// This can be used as a test harness to handle initialization
 /// and reporting.
 #[macro_export]
-macro_rules! fluent_test {
+macro_rules! rest_test {
     () => {
         #[test]
-        fn _fluent_test_runner() {
+        fn _rest_test_runner() {
             // Auto-initialize if enhanced output is enabled
             $crate::auto_initialize_for_tests();
 

--- a/tests/attribute_test.rs
+++ b/tests/attribute_test.rs
@@ -1,4 +1,4 @@
-use fluent_test::prelude::*;
+use rest::prelude::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 // Setup a new test module focused just on attribute-style fixtures

--- a/tests/fixture_test.rs
+++ b/tests/fixture_test.rs
@@ -1,5 +1,5 @@
-use fluent_test::prelude::*;
 use once_cell::sync::Lazy;
+use rest::prelude::*;
 use std::cell::RefCell;
 use std::sync::{
     Mutex,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,9 +1,9 @@
-use fluent_test::prelude::*;
+use rest::prelude::*;
 
 #[test]
 fn test_basic_assertions() {
     // Enable enhanced output for this specific test
-    fluent_test::config().enhanced_output(true).apply();
+    rest::config().enhanced_output(true).apply();
 
     let value = 42;
 
@@ -20,7 +20,7 @@ fn test_with_standard_assertions() {
     assert_eq!(value, 42);
 
     // Use enhanced output for fluent assertions
-    fluent_test::config().enhanced_output(true).apply();
+    rest::config().enhanced_output(true).apply();
     expect!(value).to_be_even();
 }
 
@@ -29,7 +29,7 @@ fn test_with_standard_assertions() {
 #[should_panic]
 fn test_failure_reporting() {
     // Enable enhanced output for this should_panic test
-    fluent_test::config().enhanced_output(true).apply();
+    rest::config().enhanced_output(true).apply();
 
     let my_special_value = 13;
     expect!(my_special_value).to_be_even();

--- a/tests/lifecycle_test.rs
+++ b/tests/lifecycle_test.rs
@@ -1,5 +1,5 @@
-use fluent_test::prelude::*;
 use once_cell::sync::Lazy;
+use rest::prelude::*;
 use std::sync::{
     Mutex,
     atomic::{AtomicUsize, Ordering},

--- a/tests/module_fixtures_test.rs
+++ b/tests/module_fixtures_test.rs
@@ -1,5 +1,5 @@
-use fluent_test::prelude::*;
 use once_cell::sync::Lazy;
+use rest::prelude::*;
 use std::cell::RefCell;
 use std::sync::{
     Mutex,


### PR DESCRIPTION
## Summary
Rename the project from fluent-test to rest to better align with other testing frameworks like Jest (JavaScript) and Pest (PHP).

## Details
- Updated package name to `rest` on crates.io
- Changed macro crate name to `rest-macros`
- Renamed API import paths from `fluent_test::*` to `rest::*`
- Updated environment variable from `FLUENT_TEST_ENHANCED_OUTPUT` to `REST_ENHANCED_OUTPUT`
- Renamed `fluent_test` macro to `rest_test`
- Updated all documentation and examples to use new name
- Updated GitHub repository URLs
- Incremented version to 0.5.0

## Test plan
- Verified all tests pass with the new names
- Ran examples to verify functionality
- Checked code with clippy to ensure there are no linting issues
- Performed a dry run of `cargo publish` to verify package is ready for release