### PR TITLE
Rename project from fluent-test to rest (v0.5.1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         id: get_version
         run: |
           MAIN_VERSION=$(grep '^version =' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
-          MACROS_VERSION=$(grep '^version =' fluent-test-macros/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          MACROS_VERSION=$(grep '^version =' rest-macros/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
           
           echo "local_version=$MAIN_VERSION" >> $GITHUB_OUTPUT
           echo "macros_version=$MACROS_VERSION" >> $GITHUB_OUTPUT
@@ -89,10 +89,10 @@ jobs:
           echo "Publishing version ${{ steps.get_version.outputs.local_version }} to crates.io..."
           
           # First publish the macros crate
-          echo "Publishing fluent-test-macros crate first..."
-          cd fluent-test-macros
+          echo "Publishing rest-macros crate first..."
+          cd rest-macros
           cargo publish --no-verify
-          echo "Successfully published fluent-test-macros to crates.io"
+          echo "Successfully published rest-macros to crates.io"
           
           # Wait a bit for crates.io to index the published crate
           echo "Waiting for crates.io to index the macros crate..."
@@ -100,9 +100,9 @@ jobs:
           
           # Then publish the main crate
           cd ..
-          echo "Publishing main fluent-test crate..."
+          echo "Publishing main rest crate..."
           cargo publish --no-verify
-          echo "Successfully published fluent-test version ${{ steps.get_version.outputs.local_version }} to crates.io"
+          echo "Successfully published rest version ${{ steps.get_version.outputs.local_version }} to crates.io"
       
       - name: No publish needed
         if: steps.version_check.outputs.newer_version != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.1 (2025-04-27)
+
+### Fixed
+
+- Version bump to fix CI issue with existing tag
+
 ## 0.5.0 (2025-04-27)
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rest"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "colored",
  "ctor",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "rest-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rest"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors = ["Romain Laneuville<romain.laneuville@hotmail.fr>"]
 description = "A fluent, Jest-like testing library for Rust"
@@ -16,7 +16,7 @@ lazy_static = "1.4.0"
 thread_local = "1.1.8"
 once_cell = "1.18.0"
 ctor = "0.2.7"
-rest-macros = { path = "./rest-macros", version = "0.5.0" }
+rest-macros = { path = "./rest-macros", version = "0.5.1" }
 
 [dev-dependencies]
 

--- a/rest-macros/Cargo.toml
+++ b/rest-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rest-macros"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors = ["Romain Laneuville<romain.laneuville@hotmail.fr>"]
 description = "Procedural macros for rest"


### PR DESCRIPTION
## Summary
Rename the project from fluent-test to rest to better align with other testing frameworks like Jest (JavaScript) and Pest (PHP).

## Details
- Updated package name to `rest` on crates.io
- Changed macro crate name to `rest-macros`
- Renamed API import paths from `fluent_test::*` to `rest::*`
- Updated environment variable from `FLUENT_TEST_ENHANCED_OUTPUT` to `REST_ENHANCED_OUTPUT`
- Renamed `fluent_test` macro to `rest_test`
- Updated all documentation and examples to use new name
- Updated GitHub repository URLs
- Bumped version to 0.5.1 to avoid CI issues with existing tags

## Test plan
- Verified all tests pass with the new names
- Ran examples to verify functionality
- Checked code with clippy to ensure there are no linting issues
- Performed a dry run of `cargo publish` to verify package is ready for release