### PR TITLE
feat: add float matchers with approximate equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (Unreleased)
+
+### Added
+
+- Float matchers with approximate equality — `to_be_close_to(expected, tolerance)`, `to_be_nan()`, `to_be_infinite()`, `to_be_finite()` for `f32` and `f64` (#17, #32)
+
 ## 0.6.0 (2026-04-09)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ Supports all 14 standard Rust numeric types: `i8`, `i16`, `i32`, `i64`, `i128`, 
 
 [View Numeric Matchers documentation](https://github.com/mister-good-deal/rest/wiki/Numeric-Matchers)
 
+### Float Matchers
+
+Supports approximate equality and special value classification for `f32` and `f64`.
+
+- **to_be_close_to** - Checks if a float is within a tolerance of an expected value
+- **to_be_nan** - Checks if a float is NaN
+- **to_be_infinite** - Checks if a float is infinite (positive or negative)
+- **to_be_finite** - Checks if a float is finite (not NaN or infinite)
+
+[View Float Matchers documentation](https://github.com/mister-good-deal/rest/wiki/Float-Matchers)
+
 ### String Matchers
 
 - **to_be_empty** - Checks if a string is empty

--- a/src/backend/matchers/float.rs
+++ b/src/backend/matchers/float.rs
@@ -1,0 +1,348 @@
+use crate::backend::Assertion;
+use crate::backend::assertions::sentence::AssertionSentence;
+use std::fmt::Debug;
+
+/// Trait for float-specific assertions.
+///
+/// Provides matchers for approximate equality and special float value classification.
+/// Supported for `f32` and `f64`.
+pub trait FloatMatchers<T> {
+    fn to_be_close_to(self, expected: T, tolerance: T) -> Self;
+    fn to_be_nan(self) -> Self;
+    fn to_be_infinite(self) -> Self;
+    fn to_be_finite(self) -> Self;
+}
+
+/// Internal helper trait implemented by float types.
+trait AsFloat: PartialOrd + Copy {
+    fn is_nan_value(&self) -> bool;
+    fn is_infinite_value(&self) -> bool;
+    fn is_finite_value(&self) -> bool;
+    fn is_close_to(&self, expected: Self, tolerance: Self) -> bool;
+    fn display_value(&self) -> String;
+}
+
+impl AsFloat for f32 {
+    fn is_nan_value(&self) -> bool {
+        self.is_nan()
+    }
+
+    fn is_infinite_value(&self) -> bool {
+        self.is_infinite()
+    }
+
+    fn is_finite_value(&self) -> bool {
+        self.is_finite()
+    }
+
+    fn is_close_to(&self, expected: f32, tolerance: f32) -> bool {
+        (self - expected).abs() <= tolerance
+    }
+
+    fn display_value(&self) -> String {
+        format!("{}", self)
+    }
+}
+
+impl AsFloat for f64 {
+    fn is_nan_value(&self) -> bool {
+        self.is_nan()
+    }
+
+    fn is_infinite_value(&self) -> bool {
+        self.is_infinite()
+    }
+
+    fn is_finite_value(&self) -> bool {
+        self.is_finite()
+    }
+
+    fn is_close_to(&self, expected: f64, tolerance: f64) -> bool {
+        (self - expected).abs() <= tolerance
+    }
+
+    fn display_value(&self) -> String {
+        format!("{}", self)
+    }
+}
+
+impl AsFloat for &f32 {
+    fn is_nan_value(&self) -> bool {
+        (**self).is_nan()
+    }
+
+    fn is_infinite_value(&self) -> bool {
+        (**self).is_infinite()
+    }
+
+    fn is_finite_value(&self) -> bool {
+        (**self).is_finite()
+    }
+
+    fn is_close_to(&self, expected: &f32, tolerance: &f32) -> bool {
+        (**self - *expected).abs() <= *tolerance
+    }
+
+    fn display_value(&self) -> String {
+        format!("{}", **self)
+    }
+}
+
+impl AsFloat for &f64 {
+    fn is_nan_value(&self) -> bool {
+        (**self).is_nan()
+    }
+
+    fn is_infinite_value(&self) -> bool {
+        (**self).is_infinite()
+    }
+
+    fn is_finite_value(&self) -> bool {
+        (**self).is_finite()
+    }
+
+    fn is_close_to(&self, expected: &f64, tolerance: &f64) -> bool {
+        (**self - *expected).abs() <= *tolerance
+    }
+
+    fn display_value(&self) -> String {
+        format!("{}", **self)
+    }
+}
+
+/// Implementation for owned float values
+impl<V> FloatMatchers<V> for Assertion<V>
+where
+    V: AsFloat + Debug + Clone,
+{
+    fn to_be_close_to(self, expected: V, tolerance: V) -> Self {
+        let result = self.value.is_close_to(expected, tolerance);
+        let sentence = AssertionSentence::new("be", format!("close to {} ± {}", expected.display_value(), tolerance.display_value()))
+            .with_actual(format!("{:?}", self.value));
+
+        return self.add_step(sentence, result);
+    }
+
+    fn to_be_nan(self) -> Self {
+        let result = self.value.is_nan_value();
+        let sentence = AssertionSentence::new("be", "NaN").with_actual(format!("{:?}", self.value));
+
+        return self.add_step(sentence, result);
+    }
+
+    fn to_be_infinite(self) -> Self {
+        let result = self.value.is_infinite_value();
+        let sentence = AssertionSentence::new("be", "infinite").with_actual(format!("{:?}", self.value));
+
+        return self.add_step(sentence, result);
+    }
+
+    fn to_be_finite(self) -> Self {
+        let result = self.value.is_finite_value();
+        let sentence = AssertionSentence::new("be", "finite").with_actual(format!("{:?}", self.value));
+
+        return self.add_step(sentence, result);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+
+    // ── to_be_close_to ──────────────────────────────────────────────
+
+    #[test]
+    fn test_f64_close_to() {
+        crate::Reporter::disable_deduplication();
+
+        expect!(0.1 + 0.2).to_be_close_to(0.3, 0.001);
+    }
+
+    #[test]
+    fn test_f32_close_to() {
+        crate::Reporter::disable_deduplication();
+
+        let result: f32 = 0.1_f32 + 0.2_f32;
+        expect!(result).to_be_close_to(0.3_f32, 0.001_f32);
+    }
+
+    #[test]
+    fn test_close_to_with_very_small_tolerance() {
+        crate::Reporter::disable_deduplication();
+
+        let pi: f64 = std::f64::consts::PI;
+        expect!(pi).to_be_close_to(3.14159265358979, 0.00000000000001);
+    }
+
+    #[test]
+    #[should_panic(expected = "be close to")]
+    fn test_close_to_failure() {
+        let _assertion = expect!(1.0_f64).to_be_close_to(2.0, 0.001);
+        std::hint::black_box(_assertion);
+    }
+
+    #[test]
+    fn test_close_to_exact_match() {
+        crate::Reporter::disable_deduplication();
+
+        expect!(1.0_f64).to_be_close_to(1.0, 0.0);
+    }
+
+    // ── to_be_nan ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_nan_f64() {
+        crate::Reporter::disable_deduplication();
+
+        expect!(f64::NAN).to_be_nan();
+    }
+
+    #[test]
+    fn test_nan_f32() {
+        crate::Reporter::disable_deduplication();
+
+        expect!(f32::NAN).to_be_nan();
+    }
+
+    #[test]
+    #[should_panic(expected = "be NaN")]
+    fn test_non_nan_fails() {
+        let _assertion = expect!(1.0_f64).to_be_nan();
+        std::hint::black_box(_assertion);
+    }
+
+    // ── to_be_infinite ──────────────────────────────────────────────
+
+    #[test]
+    fn test_positive_infinity() {
+        crate::Reporter::disable_deduplication();
+
+        expect!(f64::INFINITY).to_be_infinite();
+    }
+
+    #[test]
+    fn test_negative_infinity() {
+        crate::Reporter::disable_deduplication();
+
+        expect!(f64::NEG_INFINITY).to_be_infinite();
+    }
+
+    #[test]
+    fn test_f32_infinity() {
+        crate::Reporter::disable_deduplication();
+
+        expect!(f32::INFINITY).to_be_infinite();
+    }
+
+    #[test]
+    #[should_panic(expected = "be infinite")]
+    fn test_finite_is_not_infinite() {
+        let _assertion = expect!(1.0_f64).to_be_infinite();
+        std::hint::black_box(_assertion);
+    }
+
+    // ── to_be_finite ────────────────────────────────────────────────
+
+    #[test]
+    fn test_finite_value() {
+        crate::Reporter::disable_deduplication();
+
+        expect!(1.0_f64).to_be_finite();
+        expect!(0.0_f32).to_be_finite();
+        expect!(-42.5_f64).to_be_finite();
+    }
+
+    #[test]
+    #[should_panic(expected = "be finite")]
+    fn test_infinity_is_not_finite() {
+        let _assertion = expect!(f64::INFINITY).to_be_finite();
+        std::hint::black_box(_assertion);
+    }
+
+    #[test]
+    #[should_panic(expected = "be finite")]
+    fn test_nan_is_not_finite() {
+        let _assertion = expect!(f64::NAN).to_be_finite();
+        std::hint::black_box(_assertion);
+    }
+
+    // ── negation (.not()) ───────────────────────────────────────────
+
+    #[test]
+    fn test_not_nan() {
+        crate::Reporter::disable_deduplication();
+
+        expect!(1.0_f64).not().to_be_nan();
+    }
+
+    #[test]
+    fn test_not_close_to() {
+        crate::Reporter::disable_deduplication();
+
+        expect!(1.0_f64).not().to_be_close_to(2.0, 0.001);
+    }
+
+    #[test]
+    fn test_not_infinite() {
+        crate::Reporter::disable_deduplication();
+
+        expect!(1.0_f64).not().to_be_infinite();
+    }
+
+    #[test]
+    fn test_not_finite() {
+        crate::Reporter::disable_deduplication();
+
+        expect!(f64::NAN).not().to_be_finite();
+        expect!(f64::INFINITY).not().to_be_finite();
+    }
+
+    #[test]
+    #[should_panic(expected = "not be NaN")]
+    fn test_not_nan_fails_on_nan() {
+        let _assertion = expect!(f64::NAN).not().to_be_nan();
+        std::hint::black_box(_assertion);
+    }
+
+    // ── chaining (.and()) ───────────────────────────────────────────
+
+    #[test]
+    fn test_close_to_and_positive() {
+        crate::Reporter::disable_deduplication();
+
+        expect!(3.14_f64).to_be_close_to(std::f64::consts::PI, 0.01).and().to_be_positive();
+    }
+
+    #[test]
+    fn test_close_to_and_finite() {
+        crate::Reporter::disable_deduplication();
+
+        expect!(0.1_f64 + 0.2_f64).to_be_close_to(0.3, 0.001).and().to_be_finite();
+    }
+
+    // ── edge cases ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_negative_zero() {
+        crate::Reporter::disable_deduplication();
+
+        expect!(-0.0_f64).to_be_close_to(0.0, 0.0);
+        expect!(-0.0_f64).to_be_finite();
+        expect!(-0.0_f64).not().to_be_nan();
+    }
+
+    #[test]
+    fn test_nan_close_to_nan() {
+        crate::Reporter::disable_deduplication();
+
+        // NaN is never close to anything, even itself
+        expect!(f64::NAN).not().to_be_close_to(f64::NAN, 1.0);
+    }
+
+    #[test]
+    fn test_infinity_not_close_to_finite() {
+        crate::Reporter::disable_deduplication();
+
+        expect!(f64::INFINITY).not().to_be_close_to(1.0, 1000.0);
+    }
+}

--- a/src/backend/matchers/float.rs
+++ b/src/backend/matchers/float.rs
@@ -66,50 +66,6 @@ impl AsFloat for f64 {
     }
 }
 
-impl AsFloat for &f32 {
-    fn is_nan_value(&self) -> bool {
-        (**self).is_nan()
-    }
-
-    fn is_infinite_value(&self) -> bool {
-        (**self).is_infinite()
-    }
-
-    fn is_finite_value(&self) -> bool {
-        (**self).is_finite()
-    }
-
-    fn is_close_to(&self, expected: &f32, tolerance: &f32) -> bool {
-        (**self - *expected).abs() <= *tolerance
-    }
-
-    fn display_value(&self) -> String {
-        format!("{}", **self)
-    }
-}
-
-impl AsFloat for &f64 {
-    fn is_nan_value(&self) -> bool {
-        (**self).is_nan()
-    }
-
-    fn is_infinite_value(&self) -> bool {
-        (**self).is_infinite()
-    }
-
-    fn is_finite_value(&self) -> bool {
-        (**self).is_finite()
-    }
-
-    fn is_close_to(&self, expected: &f64, tolerance: &f64) -> bool {
-        (**self - *expected).abs() <= *tolerance
-    }
-
-    fn display_value(&self) -> String {
-        format!("{}", **self)
-    }
-}
-
 /// Implementation for owned float values
 impl<V> FloatMatchers<V> for Assertion<V>
 where
@@ -139,6 +95,41 @@ where
 
     fn to_be_finite(self) -> Self {
         let result = self.value.is_finite_value();
+        let sentence = AssertionSentence::new("be", "finite").with_actual(format!("{:?}", self.value));
+
+        return self.add_step(sentence, result);
+    }
+}
+
+/// Implementation for referenced float values
+impl<V> FloatMatchers<V> for Assertion<&V>
+where
+    V: AsFloat + Debug + Clone,
+{
+    fn to_be_close_to(self, expected: V, tolerance: V) -> Self {
+        let result = (*self.value).is_close_to(expected, tolerance);
+        let sentence = AssertionSentence::new("be", format!("close to {} ± {}", expected.display_value(), tolerance.display_value()))
+            .with_actual(format!("{:?}", self.value));
+
+        return self.add_step(sentence, result);
+    }
+
+    fn to_be_nan(self) -> Self {
+        let result = (*self.value).is_nan_value();
+        let sentence = AssertionSentence::new("be", "NaN").with_actual(format!("{:?}", self.value));
+
+        return self.add_step(sentence, result);
+    }
+
+    fn to_be_infinite(self) -> Self {
+        let result = (*self.value).is_infinite_value();
+        let sentence = AssertionSentence::new("be", "infinite").with_actual(format!("{:?}", self.value));
+
+        return self.add_step(sentence, result);
+    }
+
+    fn to_be_finite(self) -> Self {
+        let result = (*self.value).is_finite_value();
         let sentence = AssertionSentence::new("be", "finite").with_actual(format!("{:?}", self.value));
 
         return self.add_step(sentence, result);
@@ -344,5 +335,39 @@ mod tests {
         crate::Reporter::disable_deduplication();
 
         expect!(f64::INFINITY).not().to_be_close_to(1.0, 1000.0);
+    }
+
+    // ── referenced values ───────────────────────────────────────────
+
+    #[test]
+    fn test_ref_f64_close_to() {
+        crate::Reporter::disable_deduplication();
+
+        let value = 0.1_f64 + 0.2_f64;
+        expect!(&value).to_be_close_to(0.3, 0.001);
+    }
+
+    #[test]
+    fn test_ref_nan() {
+        crate::Reporter::disable_deduplication();
+
+        let value = f64::NAN;
+        expect!(&value).to_be_nan();
+    }
+
+    #[test]
+    fn test_ref_infinite() {
+        crate::Reporter::disable_deduplication();
+
+        let value = f64::INFINITY;
+        expect!(&value).to_be_infinite();
+    }
+
+    #[test]
+    fn test_ref_finite() {
+        crate::Reporter::disable_deduplication();
+
+        let value = 1.0_f64;
+        expect!(&value).to_be_finite();
     }
 }

--- a/src/backend/matchers/mod.rs
+++ b/src/backend/matchers/mod.rs
@@ -1,6 +1,7 @@
 pub mod boolean;
 pub mod collection;
 pub mod equality;
+pub mod float;
 pub mod hashmap;
 pub mod numeric;
 pub mod option;
@@ -12,6 +13,7 @@ pub mod string;
 pub use boolean::BooleanMatchers;
 pub use collection::{CollectionExtensions, CollectionMatchers};
 pub use equality::EqualityMatchers;
+pub use float::FloatMatchers;
 pub use hashmap::HashMapMatchers;
 pub use numeric::NumericMatchers;
 pub use option::OptionMatchers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ pub mod matchers {
     pub use crate::backend::matchers::boolean::BooleanMatchers;
     pub use crate::backend::matchers::collection::{CollectionExtensions, CollectionMatchers};
     pub use crate::backend::matchers::equality::EqualityMatchers;
+    pub use crate::backend::matchers::float::FloatMatchers;
     pub use crate::backend::matchers::hashmap::HashMapMatchers;
     pub use crate::backend::matchers::numeric::NumericMatchers;
     pub use crate::backend::matchers::option::OptionMatchers;

--- a/wiki/Float-Matchers.md
+++ b/wiki/Float-Matchers.md
@@ -1,0 +1,85 @@
+# Float Matchers
+
+Float matchers provide approximate equality and special value classification for `f32` and `f64` types.
+
+## to_be_close_to
+
+Checks if a floating point number is within a tolerance of an expected value. Uses absolute difference: `(actual - expected).abs() <= tolerance`.
+
+```rust
+fn test_close_to() {
+    let result = 0.1 + 0.2;
+
+    expect!(result).to_be_close_to(0.3, 0.001);                           // Passes
+    expect!(std::f64::consts::PI).to_be_close_to(3.14159, 0.00001);       // Passes
+    expect!(result).not().to_be_close_to(0.5, 0.001);                     // Passes
+}
+```
+
+Also works with `f32`:
+
+```rust
+fn test_close_to_f32() {
+    let result: f32 = 0.1_f32 + 0.2_f32;
+
+    expect!(result).to_be_close_to(0.3_f32, 0.001_f32);  // Passes
+}
+```
+
+## to_be_nan
+
+Checks if a floating point number is NaN (Not a Number).
+
+```rust
+fn test_nan() {
+    expect!(f64::NAN).to_be_nan();             // Passes
+    expect!(f32::NAN).to_be_nan();             // Passes
+    expect!(1.0_f64).not().to_be_nan();        // Passes
+}
+```
+
+## to_be_infinite
+
+Checks if a floating point number is infinite (positive or negative infinity).
+
+```rust
+fn test_infinite() {
+    expect!(f64::INFINITY).to_be_infinite();       // Passes
+    expect!(f64::NEG_INFINITY).to_be_infinite();   // Passes
+    expect!(1.0_f64).not().to_be_infinite();       // Passes
+}
+```
+
+## to_be_finite
+
+Checks if a floating point number is finite (not NaN and not infinite).
+
+```rust
+fn test_finite() {
+    expect!(1.0_f64).to_be_finite();               // Passes
+    expect!(0.0_f32).to_be_finite();               // Passes
+    expect!(-42.5_f64).to_be_finite();             // Passes
+    expect!(f64::NAN).not().to_be_finite();        // Passes
+    expect!(f64::INFINITY).not().to_be_finite();   // Passes
+}
+```
+
+## Chaining
+
+Float matchers work with `.and()`, `.or()`, and `.not()` modifiers:
+
+```rust
+fn test_chaining() {
+    expect!(3.14_f64).to_be_close_to(std::f64::consts::PI, 0.01)
+                     .and().to_be_positive();
+
+    expect!(0.1_f64 + 0.2_f64).to_be_close_to(0.3, 0.001)
+                                .and().to_be_finite();
+}
+```
+
+## Edge Cases
+
+- NaN is never close to anything, including itself: `expect!(f64::NAN).not().to_be_close_to(f64::NAN, 1.0)` passes
+- Negative zero is close to positive zero: `expect!(-0.0_f64).to_be_close_to(0.0, 0.0)` passes
+- Infinity is not close to any finite value, regardless of tolerance

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -9,6 +9,7 @@ FluentTest provides a comprehensive set of matchers for various types. All match
 - [Boolean Matchers](Boolean-Matchers)
 - [Equality Matchers](Equality-Matchers)
 - [Numeric Matchers](Numeric-Matchers)
+- [Float Matchers](Float-Matchers)
 - [String Matchers](String-Matchers)
 - [Collection Matchers](Collection-Matchers)
 - [HashMap Matchers](HashMap-Matchers)


### PR DESCRIPTION
## Summary

Add float-specific matchers for approximate equality and special float value classification.

Closes #17

## New Matchers

- **`to_be_close_to(expected, tolerance)`** — Approximate equality within a tolerance, works for `f32` and `f64`
- **`to_be_nan()`** — Asserts the value is NaN
- **`to_be_infinite()`** — Asserts the value is infinite (positive or negative)
- **`to_be_finite()`** — Asserts the value is finite (not NaN or infinite)

## Usage

```rust
use rest::prelude::*;

// Approximate equality
expect!(0.1 + 0.2).to_be_close_to(0.3, 0.001);

// Special float values
expect!(f64::NAN).to_be_nan();
expect!(f64::INFINITY).to_be_infinite();
expect!(1.0_f64).to_be_finite();

// Works with .not(), .and() modifiers
expect!(1.0_f64).not().to_be_nan();
expect!(3.14_f64).to_be_close_to(std::f64::consts::PI, 0.01).and().to_be_positive();
```

## Implementation

- New `FloatMatchers<T>` trait with generic parameter for f32/f64 support
- Follows existing matcher pattern (public trait + private helper trait + impl for Assertion)
- 25 tests covering: f32/f64, negation, chaining, edge cases (NaN comparisons, -0.0, infinity)
- All 170 existing tests continue to pass