### PR TITLE
refactor: reduce code duplication in matcher helper traits

### DIFF
--- a/src/backend/matchers/collection.rs
+++ b/src/backend/matchers/collection.rs
@@ -28,157 +28,53 @@ trait AsCollection {
         U: PartialEq<Self::Item>;
 }
 
-// Implement AsCollection for slice references
-impl<T: PartialEq> AsCollection for &[T] {
-    type Item = T;
+/// Macro to generate AsCollection implementations for types that deref to slices.
+/// All supported types provide `.len()` and `.iter()` through auto-deref to `[T]`.
+macro_rules! impl_as_collection {
+    ([$($generics:tt)*] $ty:ty) => {
+        impl<$($generics)*> AsCollection for $ty {
+            type Item = T;
 
-    fn is_empty(&self) -> bool {
-        <[T]>::is_empty(self)
-    }
+            fn is_empty(&self) -> bool {
+                self.len() == 0
+            }
 
-    fn length(&self) -> usize {
-        self.len()
-    }
+            fn length(&self) -> usize {
+                self.len()
+            }
 
-    fn contains_item<U>(&self, item: &U) -> bool
-    where
-        U: PartialEq<Self::Item>,
-    {
-        self.iter().any(|x| item == x)
-    }
+            fn contains_item<U>(&self, item: &U) -> bool
+            where
+                U: PartialEq<Self::Item>,
+            {
+                self.iter().any(|x| item == x)
+            }
 
-    fn contains_all_items<U>(&self, items: &[U]) -> bool
-    where
-        U: PartialEq<Self::Item>,
-    {
-        items.iter().all(|item| self.contains_item(item))
-    }
+            fn contains_all_items<U>(&self, items: &[U]) -> bool
+            where
+                U: PartialEq<Self::Item>,
+            {
+                items.iter().all(|item| self.contains_item(item))
+            }
 
-    fn equals_items<U>(&self, other: &[U]) -> bool
-    where
-        U: PartialEq<Self::Item>,
-    {
-        if self.len() != other.len() {
-            return false;
+            fn equals_items<U>(&self, other: &[U]) -> bool
+            where
+                U: PartialEq<Self::Item>,
+            {
+                if self.len() != other.len() {
+                    return false;
+                }
+
+                self.iter().zip(other.iter()).all(|(a, b)| b == a)
+            }
         }
-
-        self.iter().zip(other.iter()).all(|(a, b)| b == a)
-    }
+    };
 }
 
-// Implement AsCollection for Vec references
-impl<T: PartialEq> AsCollection for &Vec<T> {
-    type Item = T;
-
-    fn is_empty(&self) -> bool {
-        Vec::is_empty(self)
-    }
-
-    fn length(&self) -> usize {
-        self.len()
-    }
-
-    fn contains_item<U>(&self, item: &U) -> bool
-    where
-        U: PartialEq<Self::Item>,
-    {
-        self.iter().any(|x| item == x)
-    }
-
-    fn contains_all_items<U>(&self, items: &[U]) -> bool
-    where
-        U: PartialEq<Self::Item>,
-    {
-        items.iter().all(|item| self.contains_item(item))
-    }
-
-    fn equals_items<U>(&self, other: &[U]) -> bool
-    where
-        U: PartialEq<Self::Item>,
-    {
-        if self.len() != other.len() {
-            return false;
-        }
-
-        self.iter().zip(other.iter()).all(|(a, b)| b == a)
-    }
-}
-
-// Implement AsCollection for owned Vecs
-impl<T: PartialEq> AsCollection for Vec<T> {
-    type Item = T;
-
-    fn is_empty(&self) -> bool {
-        Vec::is_empty(self)
-    }
-
-    fn length(&self) -> usize {
-        self.len()
-    }
-
-    fn contains_item<U>(&self, item: &U) -> bool
-    where
-        U: PartialEq<Self::Item>,
-    {
-        self.iter().any(|x| item == x)
-    }
-
-    fn contains_all_items<U>(&self, items: &[U]) -> bool
-    where
-        U: PartialEq<Self::Item>,
-    {
-        items.iter().all(|item| self.contains_item(item))
-    }
-
-    fn equals_items<U>(&self, other: &[U]) -> bool
-    where
-        U: PartialEq<Self::Item>,
-    {
-        if self.len() != other.len() {
-            return false;
-        }
-
-        self.iter().zip(other.iter()).all(|(a, b)| b == a)
-    }
-}
-
-// Implement AsCollection for array references
-impl<T: PartialEq, const N: usize> AsCollection for &[T; N] {
-    type Item = T;
-
-    fn is_empty(&self) -> bool {
-        N == 0
-    }
-
-    fn length(&self) -> usize {
-        N
-    }
-
-    fn contains_item<U>(&self, item: &U) -> bool
-    where
-        U: PartialEq<Self::Item>,
-    {
-        self.iter().any(|x| item == x)
-    }
-
-    fn contains_all_items<U>(&self, items: &[U]) -> bool
-    where
-        U: PartialEq<Self::Item>,
-    {
-        items.iter().all(|item| self.contains_item(item))
-    }
-
-    fn equals_items<U>(&self, other: &[U]) -> bool
-    where
-        U: PartialEq<Self::Item>,
-    {
-        if N != other.len() {
-            return false;
-        }
-
-        self.iter().zip(other.iter()).all(|(a, b)| b == a)
-    }
-}
+impl_as_collection!([T: PartialEq] &[T]);
+impl_as_collection!([T: PartialEq] &Vec<T>);
+impl_as_collection!([T: PartialEq] Vec<T>);
+impl_as_collection!([T: PartialEq, const N: usize] &[T; N]);
 
 // Implementation of CollectionMatchers that works with any type implementing AsCollection
 impl<T, V> CollectionMatchers<T> for Assertion<V>

--- a/src/backend/matchers/hashmap.rs
+++ b/src/backend/matchers/hashmap.rs
@@ -36,71 +36,46 @@ trait AsHashMap<K, V> {
         R: PartialEq + ?Sized;
 }
 
-// Implementation for &HashMap<K, V>
-impl<K, V> AsHashMap<K, V> for &HashMap<K, V>
-where
-    K: Hash + Eq,
-    V: Clone,
-{
-    fn is_map_empty(&self) -> bool {
-        self.is_empty()
-    }
+/// Macro to generate AsHashMap implementations for owned and borrowed HashMap types.
+macro_rules! impl_as_hashmap {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl<K, V> AsHashMap<K, V> for $ty
+            where
+                K: Hash + Eq,
+                V: Clone,
+            {
+                fn is_map_empty(&self) -> bool {
+                    self.is_empty()
+                }
 
-    fn map_length(&self) -> usize {
-        self.len()
-    }
+                fn map_length(&self) -> usize {
+                    self.len()
+                }
 
-    fn map_contains_key<Q>(&self, key: &Q) -> bool
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
-    {
-        self.contains_key(key)
-    }
+                fn map_contains_key<Q>(&self, key: &Q) -> bool
+                where
+                    K: Borrow<Q>,
+                    Q: Hash + Eq + ?Sized,
+                {
+                    self.contains_key(key)
+                }
 
-    fn map_contains_entry<Q, R>(&self, key: &Q, value: &R) -> bool
-    where
-        K: Borrow<Q>,
-        V: Borrow<R>,
-        Q: Hash + Eq + ?Sized,
-        R: PartialEq + ?Sized,
-    {
-        self.get(key).is_some_and(|v| v.borrow() == value)
-    }
+                fn map_contains_entry<Q, R>(&self, key: &Q, value: &R) -> bool
+                where
+                    K: Borrow<Q>,
+                    V: Borrow<R>,
+                    Q: Hash + Eq + ?Sized,
+                    R: PartialEq + ?Sized,
+                {
+                    self.get(key).is_some_and(|v| v.borrow() == value)
+                }
+            }
+        )+
+    };
 }
 
-// Implementation for HashMap<K, V>
-impl<K, V> AsHashMap<K, V> for HashMap<K, V>
-where
-    K: Hash + Eq,
-    V: Clone,
-{
-    fn is_map_empty(&self) -> bool {
-        self.is_empty()
-    }
-
-    fn map_length(&self) -> usize {
-        self.len()
-    }
-
-    fn map_contains_key<Q>(&self, key: &Q) -> bool
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
-    {
-        self.contains_key(key)
-    }
-
-    fn map_contains_entry<Q, R>(&self, key: &Q, value: &R) -> bool
-    where
-        K: Borrow<Q>,
-        V: Borrow<R>,
-        Q: Hash + Eq + ?Sized,
-        R: PartialEq + ?Sized,
-    {
-        self.get(key).is_some_and(|v| v.borrow() == value)
-    }
-}
+impl_as_hashmap!(&HashMap<K, V>, HashMap<K, V>);
 
 // Single implementation for any type that implements AsHashMap
 impl<M, K, V> HashMapMatchers<K, V> for Assertion<M>

--- a/src/backend/matchers/numeric.rs
+++ b/src/backend/matchers/numeric.rs
@@ -78,119 +78,75 @@ impl_numeric_signed!(i8, i16, i32, i64, i128, isize);
 impl_numeric_unsigned!(u8, u16, u32, u64, u128, usize);
 impl_numeric_float!(f32, f64);
 
-/// Implementation for owned numeric values
-impl<V> NumericMatchers<V> for Assertion<V>
-where
-    V: Numeric + Debug + Clone,
-{
-    fn to_be_positive(self) -> Self {
-        let result = self.value > V::zero();
-        let sentence = AssertionSentence::new("be", "positive").with_actual(format!("{:?}", self.value));
+/// Helper trait to abstract over owned and borrowed numeric values.
+/// Allows a single `NumericMatchers` implementation for both `Assertion<V>` and `Assertion<&V>`.
+trait AsNumeric {
+    type Num: Numeric;
 
-        return self.add_step(sentence, result);
-    }
-
-    fn to_be_negative(self) -> Self {
-        let result = self.value.is_negative();
-        let sentence = AssertionSentence::new("be", "negative").with_actual(format!("{:?}", self.value));
-
-        return self.add_step(sentence, result);
-    }
-
-    fn to_be_zero(self) -> Self {
-        let result = self.value == V::zero();
-        let sentence = AssertionSentence::new("be", "zero").with_actual(format!("{:?}", self.value));
-
-        return self.add_step(sentence, result);
-    }
-
-    fn to_be_greater_than(self, expected: V) -> Self {
-        let result = self.value > expected;
-        let sentence = AssertionSentence::new("be", format!("greater than {}", expected)).with_actual(format!("{:?}", self.value));
-
-        return self.add_step(sentence, result);
-    }
-
-    fn to_be_greater_than_or_equal(self, expected: V) -> Self {
-        let result = self.value >= expected;
-        let sentence =
-            AssertionSentence::new("be", format!("greater than or equal to {}", expected)).with_actual(format!("{:?}", self.value));
-
-        return self.add_step(sentence, result);
-    }
-
-    fn to_be_less_than(self, expected: V) -> Self {
-        let result = self.value < expected;
-        let sentence = AssertionSentence::new("be", format!("less than {}", expected)).with_actual(format!("{:?}", self.value));
-
-        return self.add_step(sentence, result);
-    }
-
-    fn to_be_less_than_or_equal(self, expected: V) -> Self {
-        let result = self.value <= expected;
-        let sentence = AssertionSentence::new("be", format!("less than or equal to {}", expected)).with_actual(format!("{:?}", self.value));
-
-        return self.add_step(sentence, result);
-    }
-
-    fn to_be_in_range(self, range: Range<V>) -> Self {
-        let result = range.contains(&self.value);
-        let sentence =
-            AssertionSentence::new("be", format!("in range {}..{}", range.start, range.end)).with_actual(format!("{:?}", self.value));
-
-        return self.add_step(sentence, result);
-    }
-
-    fn to_be_even(self) -> Self {
-        let result = self.value.is_even();
-        let sentence = AssertionSentence::new("be", "even").with_actual(format!("{:?}", self.value));
-
-        return self.add_step(sentence, result);
-    }
-
-    fn to_be_odd(self) -> Self {
-        let result = self.value.is_odd();
-        let sentence = AssertionSentence::new("be", "odd").with_actual(format!("{:?}", self.value));
-
-        return self.add_step(sentence, result);
-    }
+    fn as_num(&self) -> Self::Num;
 }
 
-/// Implementation for referenced numeric values
-impl<V> NumericMatchers<V> for Assertion<&V>
+/// Generate `AsNumeric` implementations for each concrete numeric type and its reference.
+macro_rules! impl_as_numeric {
+    ($($t:ty),*) => {
+        $(
+            impl AsNumeric for $t {
+                type Num = $t;
+
+                fn as_num(&self) -> $t {
+                    *self
+                }
+            }
+
+            impl AsNumeric for &$t {
+                type Num = $t;
+
+                fn as_num(&self) -> $t {
+                    **self
+                }
+            }
+        )*
+    };
+}
+
+impl_as_numeric!(i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, f32, f64);
+
+/// Unified implementation for both owned and referenced numeric values
+impl<A, V> NumericMatchers<V> for Assertion<A>
 where
+    A: AsNumeric<Num = V> + Debug + Clone,
     V: Numeric + Debug + Clone,
 {
     fn to_be_positive(self) -> Self {
-        let result = *self.value > V::zero();
+        let result = self.value.as_num() > V::zero();
         let sentence = AssertionSentence::new("be", "positive").with_actual(format!("{:?}", self.value));
 
         return self.add_step(sentence, result);
     }
 
     fn to_be_negative(self) -> Self {
-        let result = self.value.is_negative();
+        let result = self.value.as_num().is_negative();
         let sentence = AssertionSentence::new("be", "negative").with_actual(format!("{:?}", self.value));
 
         return self.add_step(sentence, result);
     }
 
     fn to_be_zero(self) -> Self {
-        let result = *self.value == V::zero();
+        let result = self.value.as_num() == V::zero();
         let sentence = AssertionSentence::new("be", "zero").with_actual(format!("{:?}", self.value));
 
         return self.add_step(sentence, result);
     }
 
     fn to_be_greater_than(self, expected: V) -> Self {
-        let result = *self.value > expected;
+        let result = self.value.as_num() > expected;
         let sentence = AssertionSentence::new("be", format!("greater than {}", expected)).with_actual(format!("{:?}", self.value));
 
         return self.add_step(sentence, result);
     }
 
     fn to_be_greater_than_or_equal(self, expected: V) -> Self {
-        let result = *self.value >= expected;
+        let result = self.value.as_num() >= expected;
         let sentence =
             AssertionSentence::new("be", format!("greater than or equal to {}", expected)).with_actual(format!("{:?}", self.value));
 
@@ -198,21 +154,22 @@ where
     }
 
     fn to_be_less_than(self, expected: V) -> Self {
-        let result = *self.value < expected;
+        let result = self.value.as_num() < expected;
         let sentence = AssertionSentence::new("be", format!("less than {}", expected)).with_actual(format!("{:?}", self.value));
 
         return self.add_step(sentence, result);
     }
 
     fn to_be_less_than_or_equal(self, expected: V) -> Self {
-        let result = *self.value <= expected;
+        let result = self.value.as_num() <= expected;
         let sentence = AssertionSentence::new("be", format!("less than or equal to {}", expected)).with_actual(format!("{:?}", self.value));
 
         return self.add_step(sentence, result);
     }
 
     fn to_be_in_range(self, range: Range<V>) -> Self {
-        let result = range.contains(self.value);
+        let v = self.value.as_num();
+        let result = range.contains(&v);
         let sentence =
             AssertionSentence::new("be", format!("in range {}..{}", range.start, range.end)).with_actual(format!("{:?}", self.value));
 
@@ -220,14 +177,14 @@ where
     }
 
     fn to_be_even(self) -> Self {
-        let result = self.value.is_even();
+        let result = self.value.as_num().is_even();
         let sentence = AssertionSentence::new("be", "even").with_actual(format!("{:?}", self.value));
 
         return self.add_step(sentence, result);
     }
 
     fn to_be_odd(self) -> Self {
-        let result = self.value.is_odd();
+        let result = self.value.as_num().is_odd();
         let sentence = AssertionSentence::new("be", "odd").with_actual(format!("{:?}", self.value));
 
         return self.add_step(sentence, result);

--- a/src/backend/matchers/option.rs
+++ b/src/backend/matchers/option.rs
@@ -22,51 +22,36 @@ trait AsOption {
         U: PartialEq<Self::Item>;
 }
 
-// Implementation for Option<T>
-impl<T: Debug + PartialEq> AsOption for Option<T> {
-    type Item = T;
+/// Macro to generate AsOption implementations for owned and borrowed Option types.
+macro_rules! impl_as_option {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl<T: Debug + PartialEq> AsOption for $ty {
+                type Item = T;
 
-    fn is_some_option(&self) -> bool {
-        self.is_some()
-    }
+                fn is_some_option(&self) -> bool {
+                    self.is_some()
+                }
 
-    fn is_none_option(&self) -> bool {
-        self.is_none()
-    }
+                fn is_none_option(&self) -> bool {
+                    self.is_none()
+                }
 
-    fn contains_item<U>(&self, expected: &U) -> bool
-    where
-        U: PartialEq<Self::Item>,
-    {
-        match self {
-            Some(actual) => expected == actual,
-            None => false,
-        }
-    }
+                fn contains_item<U>(&self, expected: &U) -> bool
+                where
+                    U: PartialEq<Self::Item>,
+                {
+                    match self {
+                        Some(actual) => expected == actual,
+                        None => false,
+                    }
+                }
+            }
+        )+
+    };
 }
 
-// Implementation for &Option<T>
-impl<T: Debug + PartialEq> AsOption for &Option<T> {
-    type Item = T;
-
-    fn is_some_option(&self) -> bool {
-        self.is_some()
-    }
-
-    fn is_none_option(&self) -> bool {
-        self.is_none()
-    }
-
-    fn contains_item<U>(&self, expected: &U) -> bool
-    where
-        U: PartialEq<Self::Item>,
-    {
-        match self {
-            Some(actual) => expected == actual,
-            None => false,
-        }
-    }
-}
+impl_as_option!(Option<T>, &Option<T>);
 
 // Single implementation of OptionMatchers for any type that implements AsOption
 impl<T, V> OptionMatchers<T> for Assertion<V>

--- a/src/backend/matchers/result.rs
+++ b/src/backend/matchers/result.rs
@@ -18,55 +18,38 @@ trait AsResult<T: Debug + Clone, E: Debug + Clone> {
     fn contains_err<U: PartialEq<E> + Debug>(&self, expected: &U) -> bool;
 }
 
-// Implementation for Result<T, E>
-impl<T: Debug + Clone, E: Debug + Clone> AsResult<T, E> for Result<T, E> {
-    fn is_ok_result(&self) -> bool {
-        self.is_ok()
-    }
+/// Macro to generate AsResult implementations for owned and borrowed Result types.
+macro_rules! impl_as_result {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl<T: Debug + Clone, E: Debug + Clone> AsResult<T, E> for $ty {
+                fn is_ok_result(&self) -> bool {
+                    self.is_ok()
+                }
 
-    fn is_err_result(&self) -> bool {
-        self.is_err()
-    }
+                fn is_err_result(&self) -> bool {
+                    self.is_err()
+                }
 
-    fn contains_ok<U: PartialEq<T> + Debug>(&self, expected: &U) -> bool {
-        match self {
-            Ok(actual) => expected == actual,
-            Err(_) => false,
-        }
-    }
+                fn contains_ok<U: PartialEq<T> + Debug>(&self, expected: &U) -> bool {
+                    match self {
+                        Ok(actual) => expected == actual,
+                        Err(_) => false,
+                    }
+                }
 
-    fn contains_err<U: PartialEq<E> + Debug>(&self, expected: &U) -> bool {
-        match self {
-            Ok(_) => false,
-            Err(actual) => expected == actual,
-        }
-    }
+                fn contains_err<U: PartialEq<E> + Debug>(&self, expected: &U) -> bool {
+                    match self {
+                        Ok(_) => false,
+                        Err(actual) => expected == actual,
+                    }
+                }
+            }
+        )+
+    };
 }
 
-// Implementation for &Result<T, E>
-impl<T: Debug + Clone, E: Debug + Clone> AsResult<T, E> for &Result<T, E> {
-    fn is_ok_result(&self) -> bool {
-        self.is_ok()
-    }
-
-    fn is_err_result(&self) -> bool {
-        self.is_err()
-    }
-
-    fn contains_ok<U: PartialEq<T> + Debug>(&self, expected: &U) -> bool {
-        match self {
-            Ok(actual) => expected == actual,
-            Err(_) => false,
-        }
-    }
-
-    fn contains_err<U: PartialEq<E> + Debug>(&self, expected: &U) -> bool {
-        match self {
-            Ok(_) => false,
-            Err(actual) => expected == actual,
-        }
-    }
-}
+impl_as_result!(Result<T, E>, &Result<T, E>);
 
 // Single implementation for any type that implements AsResult
 impl<V, T, E> ResultMatchers<T, E> for Assertion<V>


### PR DESCRIPTION
## Summary

Reduces code duplication in the `As*` matcher helper traits by introducing declarative macros and a helper trait. Closes #16

## Changes

**5 files changed: 180 insertions, 384 deletions (−204 lines net)**

### Per-file line count (before → after)

| File | Before | After | Saved |
|---|---|---|---|
| `collection.rs` | 412 | 308 | **−104** |
| `hashmap.rs` | 279 | 254 | **−25** |
| `option.rs` | 175 | 160 | **−15** |
| `result.rs` | 188 | 171 | **−17** |
| `numeric.rs` | 486 | 443 | **−43** |
| **Total** | **1540** | **1336** | **−204** |

### Approach

- **`collection.rs`**: `impl_as_collection!` macro generates `AsCollection` impls for `&[T]`, `&Vec<T>`, `Vec<T>`, and `&[T; N]` — replacing 4 near-identical impl blocks with 1 macro + 4 one-line invocations
- **`hashmap.rs`**: `impl_as_hashmap!` macro generates `AsHashMap` impls for `&HashMap<K,V>` and `HashMap<K,V>`
- **`option.rs`**: `impl_as_option!` macro generates `AsOption` impls for `Option<T>` and `&Option<T>`
- **`result.rs`**: `impl_as_result!` macro generates `AsResult` impls for `Result<T,E>` and `&Result<T,E>`
- **`numeric.rs`**: `AsNumeric` helper trait with `impl_as_numeric!` macro unifies the two `NumericMatchers` impl blocks (`Assertion<V>` and `Assertion<&V>`) into a single generic impl

### Verification

- All 145 unit tests + integration tests + doctests pass with zero modifications
- `cargo fmt` — clean
- `cargo clippy` — no warnings
- Public API is completely unchanged