### PR TITLE
test: improve coverage for ConsoleRenderer, modifiers, and Config

### DIFF
--- a/src/backend/modifiers/and.rs
+++ b/src/backend/modifiers/and.rs
@@ -45,4 +45,45 @@ mod tests {
         // Simple test that doesn't trigger thread-local issues
         expect!(value).to_be_greater_than(30).and().to_be_less_than(50);
     }
+
+    #[test]
+    fn test_and_three_step_chain() {
+        crate::Reporter::disable_deduplication();
+        crate::Reporter::enable_silent_mode();
+
+        let value = 42;
+        expect!(value).to_be_greater_than(10).and().to_be_less_than(100).and().to_be_positive();
+
+        crate::Reporter::disable_silent_mode();
+    }
+
+    #[test]
+    fn test_and_four_step_chain() {
+        crate::Reporter::disable_deduplication();
+        crate::Reporter::enable_silent_mode();
+
+        let value = 42;
+        expect!(value).to_be_greater_than(0).and().to_be_less_than(100).and().to_be_positive().and().to_be_even();
+
+        crate::Reporter::disable_silent_mode();
+    }
+
+    #[test]
+    fn test_and_preserves_chain_state() {
+        crate::Reporter::disable_deduplication();
+        crate::Reporter::enable_silent_mode();
+
+        let value = 42;
+        let assertion = expect!(value).to_be_greater_than(10).and();
+
+        // After and(), the assertion should be in a chain
+        assert!(assertion.in_chain, "should be marked as in_chain after and()");
+        assert!(!assertion.is_final, "should not be final after and()");
+
+        // Prevent drop evaluation
+        let mut assertion = assertion;
+        assertion.evaluated = true;
+
+        crate::Reporter::disable_silent_mode();
+    }
 }

--- a/src/backend/modifiers/not.rs
+++ b/src/backend/modifiers/not.rs
@@ -49,4 +49,77 @@ mod tests {
         let result = chain.evaluate();
         assert!(result, "NOT chain with AND should evaluate to true when both conditions are true");
     }
+
+    #[test]
+    fn test_not_toggles_negation() {
+        crate::Reporter::disable_deduplication();
+        crate::Reporter::enable_silent_mode();
+
+        let value = 42;
+        let assertion = expect!(value).not();
+
+        assert!(assertion.negated, "should be negated after not()");
+
+        let mut assertion = assertion;
+        assertion.evaluated = true;
+
+        crate::Reporter::disable_silent_mode();
+    }
+
+    #[test]
+    fn test_double_not_cancels() {
+        crate::Reporter::disable_deduplication();
+        crate::Reporter::enable_silent_mode();
+
+        let value = 42;
+        let assertion = expect!(value).not().not();
+
+        assert!(!assertion.negated, "double not should cancel out negation");
+
+        let mut assertion = assertion;
+        assertion.evaluated = true;
+
+        crate::Reporter::disable_silent_mode();
+    }
+
+    #[test]
+    fn test_not_with_and_chain() {
+        crate::Reporter::disable_deduplication();
+        crate::Reporter::enable_silent_mode();
+
+        let value = 42;
+        // not equal to 100 AND positive
+        expect!(value).not().to_equal(100).and().to_be_positive();
+
+        crate::Reporter::disable_silent_mode();
+    }
+
+    #[test]
+    fn test_not_with_or_chain() {
+        crate::Reporter::disable_deduplication();
+        crate::Reporter::enable_silent_mode();
+
+        let value = 42;
+        // not equal to 42 (fail) OR positive (pass) => pass
+        expect!(value).not().to_equal(42).or().to_be_positive();
+
+        crate::Reporter::disable_silent_mode();
+    }
+
+    #[test]
+    fn test_not_preserves_chain_state() {
+        crate::Reporter::disable_deduplication();
+        crate::Reporter::enable_silent_mode();
+
+        let value = 42;
+        let assertion = expect!(value).to_be_positive().and().not();
+
+        assert!(assertion.negated, "not() should toggle negation flag");
+        assert!(assertion.in_chain, "not() should preserve in_chain status");
+
+        let mut assertion = assertion;
+        assertion.evaluated = true;
+
+        crate::Reporter::disable_silent_mode();
+    }
 }

--- a/src/backend/modifiers/or.rs
+++ b/src/backend/modifiers/or.rs
@@ -45,4 +45,57 @@ mod tests {
         // Simple test that doesn't trigger thread-local issues
         expect!(value).to_be_greater_than(100).or().to_be_less_than(100);
     }
+
+    #[test]
+    fn test_or_three_step_chain() {
+        crate::Reporter::disable_deduplication();
+        crate::Reporter::enable_silent_mode();
+
+        let value = 5;
+        // 5 != 3 (fail) OR 5 == 5 (pass) OR 5 != 7 (fail) => pass
+        expect!(value).to_equal(3).or().to_equal(5).or().to_equal(7);
+
+        crate::Reporter::disable_silent_mode();
+    }
+
+    #[test]
+    fn test_or_first_passes_short_circuit() {
+        crate::Reporter::disable_deduplication();
+        crate::Reporter::enable_silent_mode();
+
+        let value = 10;
+        // First condition passes, rest don't matter
+        expect!(value).to_be_positive().or().to_equal(999);
+
+        crate::Reporter::disable_silent_mode();
+    }
+
+    #[test]
+    fn test_or_last_passes() {
+        crate::Reporter::disable_deduplication();
+        crate::Reporter::enable_silent_mode();
+
+        let value = 42;
+        // Only last condition passes
+        expect!(value).to_equal(1).or().to_equal(2).or().to_equal(42);
+
+        crate::Reporter::disable_silent_mode();
+    }
+
+    #[test]
+    fn test_or_preserves_chain_state() {
+        crate::Reporter::disable_deduplication();
+        crate::Reporter::enable_silent_mode();
+
+        let value = 42;
+        let assertion = expect!(value).to_equal(1).or();
+
+        assert!(assertion.in_chain, "should be marked as in_chain after or()");
+        assert!(!assertion.is_final, "should not be final after or()");
+
+        let mut assertion = assertion;
+        assertion.evaluated = true;
+
+        crate::Reporter::disable_silent_mode();
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -210,4 +210,34 @@ mod tests {
         assert_eq!(bool_from_str("invalid", true), true);
         assert_eq!(bool_from_str("invalid", false), false);
     }
+
+    #[test]
+    fn test_config_apply_sets_global_state() {
+        // Apply a config with specific settings
+        let config = Config::new().use_colors(false).use_unicode_symbols(false).show_success_details(false).enhanced_output(true);
+        config.apply();
+
+        // Verify via the global config
+        {
+            let global = crate::reporter::GLOBAL_CONFIG.read().unwrap();
+            assert_eq!(global.use_colors, false);
+            assert_eq!(global.use_unicode_symbols, false);
+            assert_eq!(global.show_success_details, false);
+            assert_eq!(global.enhanced_output, true);
+        }
+
+        // Restore defaults
+        Config::new().apply();
+    }
+
+    #[test]
+    fn test_config_apply_enhanced_output_flag() {
+        let config = Config::new().enhanced_output(true);
+        config.apply();
+
+        assert!(is_enhanced_output_enabled(), "enhanced output should be enabled after apply");
+
+        // Restore defaults
+        Config::new().apply();
+    }
 }

--- a/src/frontend/console.rs
+++ b/src/frontend/console.rs
@@ -170,3 +170,343 @@ impl ConsoleRenderer {
         println!("{}", self.render_session_summary(result));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::assertions::sentence::AssertionSentence;
+    use crate::backend::{Assertion, AssertionStep, LogicalOp, TestSessionResult};
+
+    fn make_config(colors: bool, unicode: bool) -> Config {
+        Config::new().use_colors(colors).use_unicode_symbols(unicode).show_success_details(true).enhanced_output(true)
+    }
+
+    fn make_passed_assertion(expr: &'static str, verb: &str, object: &str) -> Assertion<()> {
+        let mut assertion = Assertion::new((), expr);
+        assertion.evaluated = true;
+        assertion.steps.push(AssertionStep {
+            sentence: AssertionSentence::new(verb, object).with_negation(false),
+            passed: true,
+            logical_op: None,
+        });
+        assertion
+    }
+
+    fn make_failed_assertion(expr: &'static str, verb: &str, object: &str, actual: Option<&str>) -> Assertion<()> {
+        let mut assertion = Assertion::new((), expr);
+        assertion.evaluated = true;
+        let mut sentence = AssertionSentence::new(verb, object).with_negation(false);
+        if let Some(actual_val) = actual {
+            sentence = sentence.with_actual(actual_val);
+        }
+        assertion.steps.push(AssertionStep { sentence, passed: false, logical_op: None });
+        assertion
+    }
+
+    // ---------- render_success ----------
+
+    #[test]
+    fn render_success_with_unicode_and_colors() {
+        let renderer = ConsoleRenderer::new(make_config(true, true));
+        let assertion = make_passed_assertion("value", "be", "true");
+        let output = renderer.render_success(&assertion);
+
+        // Check that the raw (unescaped) output contains the expected prefix and message
+        assert!(output.contains("✓"), "should contain unicode checkmark");
+        assert!(output.contains("value"), "should contain the expression");
+    }
+
+    #[test]
+    fn render_success_with_unicode_no_colors() {
+        let renderer = ConsoleRenderer::new(make_config(false, true));
+        let assertion = make_passed_assertion("value", "be", "true");
+        let output = renderer.render_success(&assertion);
+
+        assert!(output.starts_with("✓ "), "should start with unicode checkmark");
+        assert!(output.contains("value"), "should contain the expression");
+    }
+
+    #[test]
+    fn render_success_without_unicode_no_colors() {
+        let renderer = ConsoleRenderer::new(make_config(false, false));
+        let assertion = make_passed_assertion("value", "be", "true");
+        let output = renderer.render_success(&assertion);
+
+        assert!(output.starts_with("+ "), "should start with + prefix");
+        assert!(output.contains("value"), "should contain the expression");
+    }
+
+    #[test]
+    fn render_success_hidden_when_show_success_disabled() {
+        let config = Config::new().use_colors(false).use_unicode_symbols(false).show_success_details(false).enhanced_output(true);
+        let renderer = ConsoleRenderer::new(config);
+        let assertion = make_passed_assertion("value", "be", "true");
+        let output = renderer.render_success(&assertion);
+
+        assert!(output.is_empty(), "should return empty string when details disabled");
+    }
+
+    #[test]
+    fn render_success_no_assertions() {
+        let renderer = ConsoleRenderer::new(make_config(false, false));
+        let mut assertion = Assertion::new((), "x");
+        assertion.evaluated = true;
+        let output = renderer.render_success(&assertion);
+
+        assert!(output.contains("No assertions made"), "should note no assertions");
+    }
+
+    // ---------- render_failure ----------
+
+    #[test]
+    fn render_failure_basic_no_colors() {
+        let renderer = ConsoleRenderer::new(make_config(false, false));
+        let assertion = make_failed_assertion("count", "be", "greater than 10", Some("5"));
+        let (header, details) = renderer.render_failure(&assertion);
+
+        assert!(header.starts_with("- "), "should start with - prefix");
+        assert!(header.contains("count"), "header should contain expression");
+        assert!(details.contains("✗"), "details should contain failure symbol");
+        assert!(details.contains("got 5"), "details should contain actual value");
+    }
+
+    #[test]
+    fn render_failure_with_unicode_no_colors() {
+        let renderer = ConsoleRenderer::new(make_config(false, true));
+        let assertion = make_failed_assertion("x", "be", "even", None);
+        let (header, _details) = renderer.render_failure(&assertion);
+
+        assert!(header.starts_with("✗ "), "should start with unicode cross");
+    }
+
+    #[test]
+    fn render_failure_without_unicode_no_colors() {
+        let renderer = ConsoleRenderer::new(make_config(false, false));
+        let assertion = make_failed_assertion("x", "be", "even", None);
+        let (header, _details) = renderer.render_failure(&assertion);
+
+        assert!(header.starts_with("- "), "should start with - prefix");
+    }
+
+    #[test]
+    fn render_failure_with_negation() {
+        let renderer = ConsoleRenderer::new(make_config(false, false));
+        let mut assertion = Assertion::new((), "value");
+        assertion.evaluated = true;
+        assertion.steps.push(AssertionStep {
+            sentence: AssertionSentence::new("be", "positive").with_negation(true),
+            passed: false,
+            logical_op: None,
+        });
+        let (header, details) = renderer.render_failure(&assertion);
+
+        assert!(header.contains("not"), "header should show negation");
+        assert!(details.contains("✗"), "details should contain failure symbol");
+    }
+
+    #[test]
+    fn render_failure_with_colors() {
+        let renderer = ConsoleRenderer::new(make_config(true, true));
+        let assertion = make_failed_assertion("x", "be", "positive", None);
+        let (header, _details) = renderer.render_failure(&assertion);
+
+        // When colors are enabled, ANSI codes are embedded.
+        // Just ensure non-empty output with expression content.
+        assert!(!header.is_empty(), "header should not be empty with colors");
+        assert!(header.contains("x"), "header should contain expression even with color codes");
+    }
+
+    // ---------- multi-step assertions ----------
+
+    #[test]
+    fn render_success_multi_step_and() {
+        let renderer = ConsoleRenderer::new(make_config(false, false));
+        let mut assertion = Assertion::new((), "n");
+        assertion.evaluated = true;
+        assertion.steps.push(AssertionStep {
+            sentence: AssertionSentence::new("be", "greater than 3").with_negation(false),
+            passed: true,
+            logical_op: Some(LogicalOp::And),
+        });
+        assertion.steps.push(AssertionStep {
+            sentence: AssertionSentence::new("be", "less than 10").with_negation(false),
+            passed: true,
+            logical_op: None,
+        });
+        let output = renderer.render_success(&assertion);
+
+        assert!(output.contains("AND"), "should contain AND connector");
+        assert!(output.contains("greater than 3"), "should contain first step");
+        assert!(output.contains("less than 10"), "should contain second step");
+    }
+
+    #[test]
+    fn render_success_multi_step_or() {
+        let renderer = ConsoleRenderer::new(make_config(false, false));
+        let mut assertion = Assertion::new((), "n");
+        assertion.evaluated = true;
+        assertion.steps.push(AssertionStep {
+            sentence: AssertionSentence::new("be", "equal to 3").with_negation(false),
+            passed: false,
+            logical_op: Some(LogicalOp::Or),
+        });
+        assertion.steps.push(AssertionStep {
+            sentence: AssertionSentence::new("be", "equal to 5").with_negation(false),
+            passed: true,
+            logical_op: None,
+        });
+        let output = renderer.render_success(&assertion);
+
+        assert!(output.contains("OR"), "should contain OR connector");
+    }
+
+    #[test]
+    fn render_failure_multi_step_details() {
+        let renderer = ConsoleRenderer::new(make_config(false, false));
+        let mut assertion = Assertion::new((), "val");
+        assertion.evaluated = true;
+        assertion.steps.push(AssertionStep {
+            sentence: AssertionSentence::new("be", "greater than 3").with_negation(false),
+            passed: true,
+            logical_op: Some(LogicalOp::And),
+        });
+        assertion.steps.push(AssertionStep {
+            sentence: AssertionSentence::new("be", "less than 2").with_negation(false).with_actual("5"),
+            passed: false,
+            logical_op: None,
+        });
+        let (_header, details) = renderer.render_failure(&assertion);
+
+        assert!(details.contains("✓"), "should mark first step as passed");
+        assert!(details.contains("✗"), "should mark second step as failed");
+        assert!(details.contains("got 5"), "should contain actual value for failed step");
+    }
+
+    #[test]
+    fn render_failure_missing_logical_op() {
+        let renderer = ConsoleRenderer::new(make_config(false, false));
+        let mut assertion = Assertion::new((), "x");
+        assertion.evaluated = true;
+        assertion.steps.push(AssertionStep {
+            sentence: AssertionSentence::new("be", "positive").with_negation(false),
+            passed: true,
+            logical_op: None, // Missing op between steps
+        });
+        assertion.steps.push(AssertionStep {
+            sentence: AssertionSentence::new("be", "even").with_negation(false),
+            passed: false,
+            logical_op: None,
+        });
+        let (header, _details) = renderer.render_failure(&assertion);
+
+        assert!(header.contains("[MISSING OP]"), "should show missing op marker");
+    }
+
+    // ---------- render_session_summary ----------
+
+    #[test]
+    fn render_session_summary_all_passed() {
+        let renderer = ConsoleRenderer::new(make_config(false, false));
+        let result = TestSessionResult { passed_count: 5, failed_count: 0, failures: vec![] };
+        let output = renderer.render_session_summary(&result);
+
+        assert!(output.contains("5 passed"), "should show passed count");
+        assert!(output.contains("0 failed"), "should show failed count");
+        assert!(!output.contains("Failure Details"), "should not show failure section");
+    }
+
+    #[test]
+    fn render_session_summary_with_failures() {
+        let renderer = ConsoleRenderer::new(make_config(false, false));
+        let failure = make_failed_assertion("x", "be", "positive", Some("-1"));
+        let result = TestSessionResult { passed_count: 3, failed_count: 1, failures: vec![failure] };
+        let output = renderer.render_session_summary(&result);
+
+        assert!(output.contains("3 passed"), "should show passed count");
+        assert!(output.contains("1 failed"), "should show failed count");
+        assert!(output.contains("Failure Details"), "should show failure section");
+        assert!(output.contains("1."), "should number failures");
+    }
+
+    #[test]
+    fn render_session_summary_with_colors() {
+        let renderer = ConsoleRenderer::new(make_config(true, true));
+        let result = TestSessionResult { passed_count: 2, failed_count: 1, failures: vec![make_failed_assertion("x", "be", "true", None)] };
+        let output = renderer.render_session_summary(&result);
+
+        // Just check that it renders something sensible
+        assert!(output.contains("Test Results"), "should contain header");
+        assert!(output.contains("passed"), "should mention passed");
+        assert!(output.contains("failed"), "should mention failed");
+        assert!(output.contains("Failure Details"), "should contain failure section");
+    }
+
+    #[test]
+    fn render_session_summary_zero_passed_and_failed() {
+        let renderer = ConsoleRenderer::new(make_config(false, false));
+        let result = TestSessionResult { passed_count: 0, failed_count: 0, failures: vec![] };
+        let output = renderer.render_session_summary(&result);
+
+        assert!(output.contains("0 passed"), "should show 0 passed");
+        assert!(output.contains("0 failed"), "should show 0 failed");
+    }
+
+    // ---------- edge cases ----------
+
+    #[test]
+    fn render_success_with_reference_expression() {
+        let renderer = ConsoleRenderer::new(make_config(false, false));
+        let mut assertion = Assertion::new((), "&my_var");
+        assertion.evaluated = true;
+        assertion.steps.push(AssertionStep {
+            sentence: AssertionSentence::new("be", "true").with_negation(false),
+            passed: true,
+            logical_op: None,
+        });
+        let output = renderer.render_success(&assertion);
+
+        // The & should be stripped from the expression
+        assert!(output.contains("my_var"), "should strip reference symbol from expression");
+        assert!(!output.contains("&my_var"), "should not contain raw reference expression");
+    }
+
+    #[test]
+    fn render_failure_multiple_failures_in_summary() {
+        let renderer = ConsoleRenderer::new(make_config(false, false));
+        let f1 = make_failed_assertion("a", "be", "positive", Some("-1"));
+        let f2 = make_failed_assertion("b", "be", "even", Some("3"));
+        let result = TestSessionResult { passed_count: 0, failed_count: 2, failures: vec![f1, f2] };
+        let output = renderer.render_session_summary(&result);
+
+        assert!(output.contains("1."), "should number first failure");
+        assert!(output.contains("2."), "should number second failure");
+        assert!(output.contains("2 failed"), "should show total failed");
+    }
+
+    #[test]
+    fn render_success_three_step_chain() {
+        let renderer = ConsoleRenderer::new(make_config(false, false));
+        let mut assertion = Assertion::new((), "n");
+        assertion.evaluated = true;
+        assertion.steps.push(AssertionStep {
+            sentence: AssertionSentence::new("be", "greater than 1").with_negation(false),
+            passed: true,
+            logical_op: Some(LogicalOp::And),
+        });
+        assertion.steps.push(AssertionStep {
+            sentence: AssertionSentence::new("be", "less than 100").with_negation(false),
+            passed: true,
+            logical_op: Some(LogicalOp::And),
+        });
+        assertion.steps.push(AssertionStep {
+            sentence: AssertionSentence::new("be", "odd").with_negation(false),
+            passed: true,
+            logical_op: None,
+        });
+        let output = renderer.render_success(&assertion);
+
+        // Should contain two AND connectors
+        let and_count = output.matches("AND").count();
+        assert_eq!(and_count, 2, "should have two AND connectors");
+    }
+}


### PR DESCRIPTION
## Summary

Improves test coverage for three under-tested areas of the codebase.

Closes #18

## Changes

### ConsoleRenderer (`src/frontend/console.rs`) — 20 new tests
Previously had **zero tests**. Now covers:
- `render_success` with unicode/colors on/off combinations
- `render_success` when `show_success_details` is disabled
- `render_success` with no assertions (empty steps)
- `render_failure` basic, with negation, with colors, with unicode
- Multi-step assertions (AND chains, OR chains, 3-step chains)
- `render_failure` details with pass/fail symbols and actual values
- Missing logical operator edge case (`[MISSING OP]`)
- `render_session_summary` — all passed, with failures, with colors, zero counts
- Reference expression stripping (`&my_var` → `my_var`)
- Multiple failures numbered in summary

### Modifiers (`src/backend/modifiers/`) — 13 new tests
- **and.rs** — 3 new: three-step chain, four-step chain, chain state verification
- **or.rs** — 4 new: three-step chain, first-passes short circuit, last-passes, chain state verification
- **not.rs** — 5 new: toggle verification, double-not cancellation, not+and chain, not+or chain, chain state preservation

### Config (`src/config.rs`) — 2 new tests
- `Config::apply()` sets global state (verifies all fields propagate)
- `Config::apply()` enhanced output flag check

## Test Results

All **180 unit tests** pass (plus integration + fixture tests). No clippy warnings.